### PR TITLE
22 filter out outliers in price history

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -106,7 +106,7 @@ def filter_outliers(values: List[Dict[str, float]], keys: List[str], outlier_fac
     """
     for i, value in enumerate(values):
         if i > 0 and i < len(values) - 1:
-            for stat_name in [keys]:
+            for stat_name in keys:
                 current = value[stat_name]
                 
                 if current == -1:

--- a/src/api.py
+++ b/src/api.py
@@ -95,6 +95,47 @@ def log_request_result(request: Request, result: Response):
     """
     mongo_manager.add_access_log(request.client.host, request.url.path, request.url.query, result.status_code)
 
+def filter_outliers(values: List[Dict[str, float]], keys: List[str], outlier_factor: float = 5, neighbour_search_range: int = 10):
+    """Filter out outliers in the values list (spikes in values that are too high or too low).
+
+    Args:
+        values (List[Dict[str, float]]): The values to filter.
+        keys (List[str]): The keys to filter.
+        outlier_factor (float, optional): The factor to use to determine if a value is an outlier. Defaults to 5.
+        neighbour_search_range (int, optional): The range to search for neighbours. Defaults to 10.
+    """
+    for i, value in enumerate(values):
+        if i > 0 and i < len(values) - 1:
+            for stat_name in [keys]:
+                current = value[stat_name]
+                
+                if current == -1:
+                    continue
+                
+                # Find the value before this one, that is not -1.
+                before = -1
+                for j in range(i - 1, max(i - neighbour_search_range, 0), -1):
+                    before = values[j][stat_name]
+                    if before != -1:
+                        break
+                    
+                if before == -1:
+                    continue
+                
+                # Find the value after this one, that is not -1.
+                after = -1
+                for j in range(i + 1, min(i + neighbour_search_range, len(values))):
+                    after = values[j][stat_name]
+                    if after != -1:
+                        break
+                
+                if after == -1:
+                    continue
+                
+                if current > before * outlier_factor and current > after * outlier_factor or\
+                    current < before / outlier_factor and current < after / outlier_factor:
+                    value[stat_name] = -1
+
 # Middleware.
 @app.middleware("http")
 async def middleware(request: Request, call_next):
@@ -183,6 +224,9 @@ async def get_item_history(request: Request, server: str, item: str, start_time:
         filters.append(lambda value: value["time"] <= end_time)
 
     values = [value for value in values if all([filter(value) for filter in filters])]
+    
+    # Filter out outliers (spikes in values that are too high or too low).
+    filter_outliers(values, ["buy_offer", "sell_offer", "sold", "bought", "month_sell_offer", "month_buy_offer"])
     
     return {"last_updated": scan_time, "history": values}
 


### PR DESCRIPTION
Before returning the price history, all outlier values are replaced by -1.
In the future, this should be done regularly on the database instead, to reduce the load.